### PR TITLE
[feat] 코멘트 전체 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/watchapedia/domain/comment/api/CommentApiController.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/api/CommentApiController.java
@@ -1,0 +1,27 @@
+package org.sopt.watchapedia.domain.comment.api;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.watchapedia.domain.comment.dto.response.CommentGetResponse;
+import org.sopt.watchapedia.domain.comment.service.CommentService;
+import org.sopt.watchapedia.global.common.ApiResponse;
+import org.sopt.watchapedia.global.common.SuccessStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/comment")
+@Controller
+public class CommentApiController {
+    private final CommentService commentService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getComments(@RequestParam String sort) {
+        List<CommentGetResponse> comments = commentService.getComments(sort);
+        return ApiResponse.success(SuccessStatus.OK, comments);
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/api/CommentApiController.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/api/CommentApiController.java
@@ -20,8 +20,8 @@ public class CommentApiController {
     private final CommentService commentService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<?>> getComments(@RequestParam String sort) {
-        List<CommentGetResponse> comments = commentService.getComments(sort);
+    public ResponseEntity<ApiResponse<?>> getComments(@RequestParam final String sort) {
+        final List<CommentGetResponse> comments = commentService.getComments(sort);
         return ApiResponse.success(SuccessStatus.OK, comments);
     }
 }

--- a/src/main/java/org/sopt/watchapedia/domain/comment/domain/Comment.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/domain/Comment.java
@@ -1,0 +1,30 @@
+package org.sopt.watchapedia.domain.comment.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+    @Column(nullable = false)
+    private String imageUrl;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private int star;
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private int likeCount;
+    @Column(nullable = false)
+    private int commentCount;
+    @Column(nullable = false)
+    private boolean isLike;
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/domain/Sort.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/domain/Sort.java
@@ -1,0 +1,19 @@
+package org.sopt.watchapedia.domain.comment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Sort {
+    DEFAULT("default", null),
+    LIKE("like", "likeCount"),
+    COMMENT("comment", "commentCount");
+
+    private final String name;
+    private final String column;
+
+    public boolean equals(String sort) {
+        return name.equals(sort);
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/domain/Sort.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/domain/Sort.java
@@ -1,9 +1,10 @@
 package org.sopt.watchapedia.domain.comment.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum Sort {
     DEFAULT("default", null),

--- a/src/main/java/org/sopt/watchapedia/domain/comment/dto/response/CommentGetResponse.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/dto/response/CommentGetResponse.java
@@ -1,0 +1,28 @@
+package org.sopt.watchapedia.domain.comment.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.sopt.watchapedia.domain.comment.domain.Comment;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CommentGetResponse(
+        String imageUrl,
+        String name,
+        int star,
+        String content,
+        int likeCount,
+        int commentCount,
+        boolean isLike
+) {
+    public static CommentGetResponse of(Comment comment) {
+        return CommentGetResponse.builder()
+                .imageUrl(comment.getImageUrl())
+                .name(comment.getName())
+                .star(comment.getStar())
+                .content(comment.getContent())
+                .likeCount(comment.getLikeCount())
+                .commentCount(comment.getCommentCount())
+                .isLike(comment.isLike())
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.watchapedia.domain.comment.repository;
+
+import org.sopt.watchapedia.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentMapper.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentMapper.java
@@ -1,0 +1,16 @@
+package org.sopt.watchapedia.domain.comment.service;
+
+import org.sopt.watchapedia.domain.comment.domain.Comment;
+import org.sopt.watchapedia.domain.comment.dto.response.CommentGetResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentMapper {
+    public List<CommentGetResponse> commentsToCommentGetResponses(List<Comment> comments) {
+        return comments.stream()
+                .map(CommentGetResponse::of)
+                .toList();
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentService.java
@@ -1,0 +1,38 @@
+package org.sopt.watchapedia.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.watchapedia.domain.comment.domain.Comment;
+import org.sopt.watchapedia.domain.comment.dto.response.CommentGetResponse;
+import org.sopt.watchapedia.domain.comment.repository.CommentRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.sopt.watchapedia.domain.comment.domain.Sort.*;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CommentService {
+    private final CommentValidator commentValidator;
+    private final CommentMapper commentMapper;
+    private final CommentRepository commentRepository;
+
+    public List<CommentGetResponse> getComments(String sort) {
+        commentValidator.validateCommentSortCriteria(sort);
+        List<Comment> comments = getCommentsAccordingToSortCriteria(sort);
+        return commentMapper.commentsToCommentGetResponses(comments);
+    }
+
+    private List<Comment> getCommentsAccordingToSortCriteria(String sort) {
+        if (DEFAULT.equals(sort)) {
+            return commentRepository.findAll();
+        } else if (LIKE.equals(sort)) {
+            return commentRepository.findAll(Sort.by(Sort.Direction.DESC, LIKE.getColumn()));
+        }
+        return commentRepository.findAll(Sort.by(Sort.Direction.DESC, COMMENT.getColumn()));
+    }
+}
+현

--- a/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentService.java
@@ -35,4 +35,3 @@ public class CommentService {
         return commentRepository.findAll(Sort.by(Sort.Direction.DESC, COMMENT.getColumn()));
     }
 }
-현

--- a/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentValidator.java
+++ b/src/main/java/org/sopt/watchapedia/domain/comment/service/CommentValidator.java
@@ -1,0 +1,23 @@
+package org.sopt.watchapedia.domain.comment.service;
+
+import org.sopt.watchapedia.domain.comment.domain.Sort;
+import org.sopt.watchapedia.global.error.BusinessException;
+import org.sopt.watchapedia.global.error.ErrorStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class CommentValidator {
+    public void validateCommentSortCriteria(String sort) {
+        boolean isValid = matchIsValidSortCriteria(sort);
+        if (!isValid) {
+            throw new BusinessException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private boolean matchIsValidSortCriteria(String sort) {
+        return Arrays.stream(Sort.values())
+                .anyMatch(s -> s.getName().equals(sort));
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/global/common/BaseTimeEntity.java
+++ b/src/main/java/org/sopt/watchapedia/global/common/BaseTimeEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
     @Column(updatable = false)
     @CreatedDate
     private LocalDateTime createdDate;


### PR DESCRIPTION
## Related Issue 📌
close #4 

## Description ✔️
- 코멘트 전체 조회 API를 구현하였습니다.
- 정렬 기준은 요청 파라미터로 받으며 default(기본), like(좋아요 수), comment(댓글 수)를 기준으로 정렬되도록 구현하였습니다.
- default, like, comment를 제외한 값을 전달받으면 예외를 던지도록 처리하였습니다.

<img width="1135" src="https://github.com/DO-SOPT-Seminar-Web-6/WatchaPedia-Server/assets/81796317/31a7cd37-0e77-4784-8f6f-bcc7c4c9ce95">

