### PR TITLE
[feat] 댓글 작성 & 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/watchapedia/domain/collection/api/CollectionApiController.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/api/CollectionApiController.java
@@ -1,25 +1,40 @@
 package org.sopt.watchapedia.domain.collection.api;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.watchapedia.domain.collection.dto.request.ReplyDeleteRequest;
+import org.sopt.watchapedia.domain.collection.dto.request.ReplySaveRequest;
 import org.sopt.watchapedia.domain.collection.dto.response.CollectionGetResponse;
 import org.sopt.watchapedia.domain.collection.service.CollectionService;
+import org.sopt.watchapedia.domain.collection.service.ReplyService;
 import org.sopt.watchapedia.global.common.ApiResponse;
 import org.sopt.watchapedia.global.common.SuccessStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/collection")
 @Controller
 public class CollectionApiController {
     private final CollectionService collectionService;
+    private final ReplyService replyService;
 
     @GetMapping("/{collectionId}")
     public ResponseEntity<ApiResponse<?>> getCollection(@PathVariable final Long collectionId) {
         final CollectionGetResponse collection = collectionService.getCollection(collectionId);
         return ApiResponse.success(SuccessStatus.OK, collection);
+    }
+
+    @PostMapping("/{collectionId}")
+    public ResponseEntity<ApiResponse<?>> saveReply(@PathVariable final Long collectionId,
+                                                    @RequestBody final ReplySaveRequest replySaveRequest) {
+        replyService.saveReply(collectionId, replySaveRequest);
+        return ApiResponse.success(SuccessStatus.CREATED);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<?>> deleteReply(@RequestBody final ReplyDeleteRequest replyDeleteRequest) {
+        replyService.deleteReply(replyDeleteRequest);
+        return ApiResponse.success(SuccessStatus.OK);
     }
 }

--- a/src/main/java/org/sopt/watchapedia/domain/collection/domain/Reply.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/domain/Reply.java
@@ -2,6 +2,7 @@ package org.sopt.watchapedia.domain.collection.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.sopt.watchapedia.domain.user.domain.User;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -20,13 +21,17 @@ public class Reply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "collection_id")
     private Collection collection;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    public static Reply createReply(String content, int likeCount, Collection collection) {
+    public static Reply createReply(String content, int likeCount, Collection collection, User user) {
         Reply reply = Reply.builder()
                 .content(content)
                 .likeCount(likeCount)
                 .build();
         reply.changeCollection(collection);
+        reply.changeUser(user);
         return reply;
     }
 
@@ -36,5 +41,13 @@ public class Reply {
         }
         collection.addReply(this);
         this.collection = collection;
+    }
+
+    private void changeUser(User user) {
+        if (this.user != null) {
+            this.user.removeReply(this);
+        }
+        user.addReply(this);
+        this.user = user;
     }
 }

--- a/src/main/java/org/sopt/watchapedia/domain/collection/dto/request/ReplyDeleteRequest.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/dto/request/ReplyDeleteRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.watchapedia.domain.collection.dto.request;
+
+public record ReplyDeleteRequest(
+        Long replyId
+) {
+}

--- a/src/main/java/org/sopt/watchapedia/domain/collection/dto/request/ReplySaveRequest.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/dto/request/ReplySaveRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.watchapedia.domain.collection.dto.request;
+
+public record ReplySaveRequest(
+        Long userId,
+        String content
+) {
+}

--- a/src/main/java/org/sopt/watchapedia/domain/collection/dto/response/ReplyGetResponse.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/dto/response/ReplyGetResponse.java
@@ -6,11 +6,13 @@ import org.sopt.watchapedia.domain.collection.domain.Reply;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record ReplyGetResponse(
+        Long replyId,
         String content,
         int likeCount
 ) {
     public static ReplyGetResponse of(Reply reply) {
         return ReplyGetResponse.builder()
+                .replyId(reply.getId())
                 .content(reply.getContent())
                 .likeCount(reply.getLikeCount())
                 .build();

--- a/src/main/java/org/sopt/watchapedia/domain/collection/service/ReplyService.java
+++ b/src/main/java/org/sopt/watchapedia/domain/collection/service/ReplyService.java
@@ -1,0 +1,43 @@
+package org.sopt.watchapedia.domain.collection.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.watchapedia.domain.collection.domain.Collection;
+import org.sopt.watchapedia.domain.collection.domain.Reply;
+import org.sopt.watchapedia.domain.collection.dto.request.ReplyDeleteRequest;
+import org.sopt.watchapedia.domain.collection.dto.request.ReplySaveRequest;
+import org.sopt.watchapedia.domain.collection.repository.CollectionRepository;
+import org.sopt.watchapedia.domain.collection.repository.ReplyRepository;
+import org.sopt.watchapedia.domain.user.domain.User;
+import org.sopt.watchapedia.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.watchapedia.domain.collection.domain.Reply.createReply;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ReplyService {
+    private final UserRepository userRepository;
+    private final CollectionRepository collectionRepository;
+    private final ReplyRepository replyRepository;
+
+    public void saveReply(Long collectionId, ReplySaveRequest replySaveRequest) {
+        User findUser = findUser(replySaveRequest);
+        Collection findCollection = findCollection(collectionId);
+        Reply reply = createReply(replySaveRequest.content(), 0, findCollection, findUser);
+        replyRepository.save(reply);
+    }
+
+    public void deleteReply(ReplyDeleteRequest replyDeleteRequest) {
+        replyRepository.deleteById(replyDeleteRequest.replyId());
+    }
+
+    private User findUser(ReplySaveRequest replySaveRequest) {
+        return userRepository.findByIdOrThrow(replySaveRequest.userId());
+    }
+
+    private Collection findCollection(Long collectionId) {
+        return collectionRepository.findByIdOrThrow(collectionId);
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/user/domain/User.java
+++ b/src/main/java/org/sopt/watchapedia/domain/user/domain/User.java
@@ -1,0 +1,33 @@
+package org.sopt.watchapedia.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.watchapedia.domain.collection.domain.Reply;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @OneToMany(mappedBy = "user")
+    private List<Reply> replies = new ArrayList<>();
+
+    public void addReply(Reply reply) {
+        replies.add(reply);
+    }
+
+    public void removeReply(Reply reply) {
+        replies.remove(reply);
+    }
+}

--- a/src/main/java/org/sopt/watchapedia/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/watchapedia/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.watchapedia.domain.user.repository;
+
+import org.sopt.watchapedia.domain.user.domain.User;
+import org.sopt.watchapedia.global.error.BusinessException;
+import org.sopt.watchapedia.global.error.ErrorStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    default User findByIdOrThrow(Long userId) {
+        return findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.ENTITY_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #10 

## Description ✔️
- 컬렉션 댓글 작성 & 삭제 API를 구현하였습니다.
- 컬렉션 상세 조회 시 응답 값으로 댓글 아이디가 필요하여, 컬렉션 상세 조회 API 스펙을 변경하였습니다.
<img width="1141" alt="스크린샷 2023-11-27 오후 12 42 00" src="https://github.com/DO-SOPT-Seminar-Web-6/WatchaPedia-Server/assets/81796317/b23b6b47-28c6-4ca6-9aa4-21c23ab8f38b">
<img width="1141" alt="스크린샷 2023-11-27 오후 12 41 28" src="https://github.com/DO-SOPT-Seminar-Web-6/WatchaPedia-Server/assets/81796317/d779074a-d7ef-468f-8ab3-4b25de434501">
